### PR TITLE
Refactor Emitter to be an interface type

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -21,7 +21,7 @@ func (r *RandomEventBody) Namespace() string {
 }
 
 func Example() {
-	emitter := new(Emitter)
+	event_controller := new(EventController)
 	/*
 		type Widget struct {
 			EventCount int
@@ -33,11 +33,11 @@ func Example() {
 	*/
 	widget := new(Widget)
 
-	emitter.RegisterHandler("widget1", widget)
+	event_controller.RegisterHandler("widget1", widget)
 
-	emitter.Emit(new(RandomEventBody))
-	emitter.Emit(new(RandomEventBody))
-	emitter.Emit(new(RandomEventBody))
+	event_controller.Emit(new(RandomEventBody))
+	event_controller.Emit(new(RandomEventBody))
+	event_controller.Emit(new(RandomEventBody))
 
 	time.Sleep(time.Millisecond * 100)
 	fmt.Println(widget.EventCount)

--- a/gomit_test.go
+++ b/gomit_test.go
@@ -28,48 +28,48 @@ func TestEmitter(t *testing.T) {
 			// Ensure that we can silently emit an event when no one is handling.
 			// and that the Emit() returns no error and 0 handlers.
 			Convey("Emits with no Handlers", func() {
-				m := new(Emitter)
+				event_controller := new(EventController)
 				eb := new(MockEventBody)
-				i, e := m.Emit(eb)
+				i, e := event_controller.Emit(eb)
 
 				So(i, ShouldBeZeroValue)
-				So(m.HandlerCount(), ShouldEqual, 0)
+				So(event_controller.HandlerCount(), ShouldEqual, 0)
 				So(e, ShouldBeNil)
 			})
 			Convey("Emits with one Handlers", func() {
-				m := new(Emitter)
+				event_controller := new(EventController)
 				mt := new(MockThing)
 
-				m.RegisterHandler("m1", mt)
+				event_controller.RegisterHandler("m1", mt)
 				eb := new(MockEventBody)
-				i, e := m.Emit(eb)
+				i, e := event_controller.Emit(eb)
 
 				So(i, ShouldEqual, 1)
-				So(m.HandlerCount(), ShouldEqual, 1)
+				So(event_controller.HandlerCount(), ShouldEqual, 1)
 				So(e, ShouldBeNil)
 			})
 		})
 
 		Convey(".RegisterHandler", func() {
 			Convey("Allows registration of a single Handler", func() {
-				m := new(Emitter)
+				event_controller := new(EventController)
 				mt := new(MockThing)
-				e := m.RegisterHandler("m1", mt)
+				e := event_controller.RegisterHandler("m1", mt)
 
-				So(m.HandlerCount(), ShouldEqual, 1)
+				So(event_controller.HandlerCount(), ShouldEqual, 1)
 				So(e, ShouldBeNil)
 			})
 
 			Convey("Does not allow a Handler to have more than one registration", func() {
-				m := new(Emitter)
+				event_controller := new(EventController)
 				mt1 := new(MockThing)
 				mt2 := new(MockThing)
 
-				m.RegisterHandler("m1", mt1)
+				event_controller.RegisterHandler("m1", mt1)
 				// Should return error signifying it was already registered.
-				e := m.RegisterHandler("m1", mt2)
+				e := event_controller.RegisterHandler("m1", mt2)
 
-				So(m.HandlerCount(), ShouldEqual, 1)
+				So(event_controller.HandlerCount(), ShouldEqual, 1)
 				So(e, ShouldNotBeNil)
 			})
 		})
@@ -77,57 +77,57 @@ func TestEmitter(t *testing.T) {
 		Convey(".HandlerCount", func() {
 			// Some simple count testing
 			Convey("Returns correct count", func() {
-				m := new(Emitter)
+				event_controller := new(EventController)
 				mt1 := new(MockThing)
 				mt2 := MockThing{}
 				mt3 := new(MockThing)
 				mt4 := new(MockThing)
 				mt5 := new(MockThing)
 
-				e := m.RegisterHandler("m1", mt1)
+				e := event_controller.RegisterHandler("m1", mt1)
 
 				So(e, ShouldBeNil)
-				So(m.HandlerCount(), ShouldEqual, 1)
+				So(event_controller.HandlerCount(), ShouldEqual, 1)
 
-				e = m.RegisterHandler("m2", &mt2)
+				e = event_controller.RegisterHandler("m2", &mt2)
 				So(e, ShouldBeNil)
-				So(m.HandlerCount(), ShouldEqual, 2)
+				So(event_controller.HandlerCount(), ShouldEqual, 2)
 
-				e = m.RegisterHandler("m3", mt3)
-				So(e, ShouldBeNil)
-
-				e = m.RegisterHandler("m4", mt4)
+				e = event_controller.RegisterHandler("m3", mt3)
 				So(e, ShouldBeNil)
 
-				e = m.RegisterHandler("m5", mt5)
+				e = event_controller.RegisterHandler("m4", mt4)
 				So(e, ShouldBeNil)
-				So(m.HandlerCount(), ShouldEqual, 5)
+
+				e = event_controller.RegisterHandler("m5", mt5)
+				So(e, ShouldBeNil)
+				So(event_controller.HandlerCount(), ShouldEqual, 5)
 
 			})
 		})
 
 		Convey(".IsHandlerRegistered", func() {
 			Convey("Returns false for Handler never registered", func() {
-				m := new(Emitter)
-				b := m.IsHandlerRegistered("MyMock1")
+				event_controller := new(EventController)
+				b := event_controller.IsHandlerRegistered("MyMock1")
 
 				So(b, ShouldBeFalse)
 			})
 			Convey("Returns true for a registered Handler", func() {
-				m := new(Emitter)
+				event_controller := new(EventController)
 				mt1 := new(MockThing)
 
-				m.RegisterHandler("MyMock1", mt1)
-				b := m.IsHandlerRegistered("MyMock1")
+				event_controller.RegisterHandler("MyMock1", mt1)
+				b := event_controller.IsHandlerRegistered("MyMock1")
 
 				So(b, ShouldBeTrue)
 			})
 			Convey("Returns false for a registered Handler that was unregistered", func() {
-				m := new(Emitter)
+				event_controller := new(EventController)
 				mt1 := new(MockThing)
-				m.RegisterHandler("M1", mt1)
-				m.UnregisterHandler("M1")
-				b := m.IsHandlerRegistered("M1")
+				event_controller.RegisterHandler("M1", mt1)
+				event_controller.UnregisterHandler("M1")
+				b := event_controller.IsHandlerRegistered("M1")
 
 				So(b, ShouldBeFalse)
 			})
@@ -135,11 +135,11 @@ func TestEmitter(t *testing.T) {
 
 		Convey(".UnregsiterHandler", func() {
 			Convey("Unregisters the Handler", func() {
-				m := new(Emitter)
+				event_controller := new(EventController)
 				mt1 := new(MockThing)
-				m.RegisterHandler("m1", mt1)
-				m.UnregisterHandler("m1")
-				b := m.IsHandlerRegistered("m1")
+				event_controller.RegisterHandler("m1", mt1)
+				event_controller.UnregisterHandler("m1")
+				b := event_controller.IsHandlerRegistered("m1")
 
 				So(b, ShouldBeFalse)
 			})
@@ -151,42 +151,42 @@ func TestEmitter(t *testing.T) {
 func TestHandler(t *testing.T) {
 	Convey("gomit.Handler", t, func() {
 		Convey("Handler is called with correct event", func() {
-			m := new(Emitter)
+			event_controller := new(EventController)
 			mt := new(MockThing)
 
-			m.RegisterHandler("m1", mt)
+			event_controller.RegisterHandler("m1", mt)
 			eb := new(MockEventBody)
 
-			i, e := m.Emit(eb)
+			i, e := event_controller.Emit(eb)
 			// We have to pause to let Handlers run.
 			time.Sleep(time.Millisecond * 100)
 
 			// One handler called
 			So(i, ShouldEqual, 1)
 			// One handler registered
-			So(m.HandlerCount(), ShouldEqual, 1)
+			So(event_controller.HandlerCount(), ShouldEqual, 1)
 			// MockThing should have Event namespace (handler was called)
 			So(mt.LastNamespace, ShouldEqual, eb.Namespace())
 			So(e, ShouldBeNil)
 		})
 		Convey("Should only emit to the first registered Handler", func() {
-			m := new(Emitter)
+			event_controller := new(EventController)
 			mt1 := new(MockThing)
 			mt2 := new(MockThing)
 			eb := new(MockEventBody)
 
-			m.RegisterHandler("m1", mt1)
+			event_controller.RegisterHandler("m1", mt1)
 			// Should return error signifying it was already registered.
-			e := m.RegisterHandler("m1", mt2)
+			e := event_controller.RegisterHandler("m1", mt2)
 			So(e, ShouldNotBeNil)
 
-			i, e := m.Emit(eb)
+			i, e := event_controller.Emit(eb)
 			// We have to pause to let Handlers run.
 			time.Sleep(time.Millisecond * 100)
 
 			// One handler called
 			So(i, ShouldEqual, 1)
-			So(m.HandlerCount(), ShouldEqual, 1)
+			So(event_controller.HandlerCount(), ShouldEqual, 1)
 			// This was the first one registered and should match
 			So(mt1.LastNamespace, ShouldEqual, eb.Namespace())
 			// This was the second one (attempted) and should not match


### PR DESCRIPTION
This changes Emitter to EventController.

The logic follows:
Emitter is closer to the language fitting an interface type that emits events. So changed to EventController to represent the behavior/state struct. Added Emitter as an interface type that emits events and RegistersHandlers as an interface type that takes handlers.

In implementation this allows the EventController to be used in separate contexts only exposing either behavior.
